### PR TITLE
Make looking for badges directory recursive. 

### DIFF
--- a/src/GamifyServiceProvider.php
+++ b/src/GamifyServiceProvider.php
@@ -82,7 +82,7 @@ class GamifyServiceProvider extends ServiceProvider
 
         $badges = [];
 
-        // Get the first folder for the app. Normally App
+        // Get the first folder for the app. For the vast majority of all projects this is "App"
         $rootFolder = substr($badgeRootNamespace, 0, strpos($badgeRootNamespace, '\\'));
 
         // Create recursive searching classes


### PR DESCRIPTION
Allows badges to be placed within other folders. 

The only problem I see happening is that right now the `BadgeType` class does a `firstOrNew` to record the badge in the database solely by name. If two badges are name the same but in different folders they would over write each other. This could be avoided by adding a column to the database with the full badge namespace and doing a `firstOrNew` based on name and namespace.

Otherwise, this code will find badges recursively just fine. 