### PR TITLE
Potential fix for assigning the user model instead of using auth

### DIFF
--- a/src/Console/stubs/point.stub
+++ b/src/Console/stubs/point.stub
@@ -30,6 +30,12 @@ class DummyClass extends PointType
      */
     public function payee()
     {
-        return $this->getSubject()->user;
+        if (property_exists($this, 'payee')) {
+            return $this->payee;
+        }
+        else
+        {
+            return $this->getSubject()->user;
+        }
     }
 }

--- a/src/HasReputations.php
+++ b/src/HasReputations.php
@@ -14,6 +14,7 @@ trait HasReputations
      */
     public function givePoint(PointType $pointType)
     {
+        $pointType->setPayee($this);
         if (!$pointType->qualifier()) {
             return false;
         }

--- a/src/PointType.php
+++ b/src/PointType.php
@@ -17,6 +17,7 @@ abstract class PointType
      * @var Model
      */
     protected $subject;
+    protected $payee;
 
     /**
      * Check qualification to give this point
@@ -36,7 +37,7 @@ abstract class PointType
     public function payee()
     {
         if (property_exists($this, 'payee')) {
-            return $this->getSubject()->{$this->payee};
+            return $this->payee;
         }
 
         throw new InvalidPayeeModel();
@@ -91,6 +92,16 @@ abstract class PointType
     public function setSubject($subject)
     {
         $this->subject = $subject;
+    }
+
+    /**
+     * Set a payee
+     *
+     * @param mixed $payee
+     */
+    public function setPayee($payee)
+    {
+        $this->payee = $payee;
     }
 
     /**


### PR DESCRIPTION
Not sure if this is 100% the best way of doing this but it has been working in my testing to allow for setting the user via the helper function as well as leaving that null and using auth user information.