### PR TITLE
allow-badges-in-sub-folders

### DIFF
--- a/src/GamifyServiceProvider.php
+++ b/src/GamifyServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\ServiceProvider;
 use QCod\Gamify\Console\MakeBadgeCommand;
 use QCod\Gamify\Console\MakePointCommand;
 use QCod\Gamify\Events\ReputationChanged;
+use Illuminate\Support\Facades\File;
 
 class GamifyServiceProvider extends ServiceProvider
 {
@@ -77,9 +78,14 @@ class GamifyServiceProvider extends ServiceProvider
 
         $badges = [];
 
-        foreach (glob(app_path('/Gamify/Badges/') . '*.php') as $file) {
-            if (is_file($file)) {
-                $badges[] = app($badgeRootNamespace . '\\' . pathinfo($file, PATHINFO_FILENAME));
+        foreach (File::allFiles(app_path('/Gamify/Badges')) as $file) {
+
+            if ($file->getExtension() === 'php') {
+
+                $subPath = str_replace('/', '\\', $file->getRelativePathName());
+                $name = str_replace('.php', '', $subPath);
+
+                $badges[] = app($badgeRootNamespace . '\\' . $name);
             }
         }
 


### PR DESCRIPTION
small tweaks to allow sub-folders under Badges folder

we can now excute command this way to achieve better orgnization of our badges:
`php artisan gamify:badge Sub-Folder\\Certain-Kind-of-Badge`